### PR TITLE
Fix cluster center dimension in sample k-means script

### DIFF
--- a/vasu_gupta/L_05.py
+++ b/vasu_gupta/L_05.py
@@ -11,7 +11,9 @@ colors=['pink','blue','green','red','orange']
 clustors={}
 
 for ix in range(k):
-    center=10.0*(2*np.random.random((X.shape[0],)) -1)
+    # each center should be the same dimension as our data points
+    # X.shape[1] gives us the number of features
+    center=10.0*(2*np.random.random((X.shape[1],)) -1)
     points=[]
 
     clustor={


### PR DESCRIPTION
## Summary
- fix bug in initializing cluster centers

## Testing
- `python3 vasu_gupta/L_05.py > /tmp/out.txt 2>&1 && head -n 5 /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_6843bba829a083308954cb9ef9b7818a